### PR TITLE
testtools 2.8.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "testtools" %}
-{% set version = "2.8.2" %}
+{% set version = "2.8.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b5c73332456ff54152062d47a58bc4f15f8e23514afec4e84775af124fb7db43
+  sha256: 76c32db2f52c4dcd539e2fbf31686ca1f9c2f5626726c8844dff7893e7122e3f
 
 build:
   number: 0


### PR DESCRIPTION
testtools 2.8.4 

**Destination channel:** Defaults

### Links

- [PKG-12581]
- dev_url:        https://github.com/testing-cabal/testtools/tree/2.8.4
- conda_forge:    https://github.com/conda-forge/testtools-feedstock
- pypi:           https://pypi.org/project/testtools/2.8.4
- pypi inspector: https://inspector.pypi.io/project/testtools/2.8.4

### Explanation of changes:

- new version number


[PKG-12581]: https://anaconda.atlassian.net/browse/PKG-12581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ